### PR TITLE
Update Makefiles to include act-mock target for easier local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ act_bootstrap: load_env
 act_terraform: load_env
 	@cd bootstrap && make act-terraform
 
+act_mock: load_env
+	@cd bootstrap && make act-mock
+
 # Check GitHub Actions setup
 check_gh:
 	@echo "Checking GitHub Actions setup..."
@@ -92,6 +95,6 @@ verify_local:
 	@test -f .env || { echo "Missing .env file"; exit 1; }
 	@test -f .env.local-test || { echo "Missing .env.local-test file"; exit 1; }
 
-.PHONY: load_env act_bootstrap act_terraform check_gh check_secrets set_secrets verify_local \
+.PHONY: load_env act_bootstrap act_terraform act_mock check_gh check_secrets set_secrets verify_local \
 	tf_init tf_fmt tf_validate tf_security tf_state_setup tf_init_aws tf_migrate_state migrate \
 	tf_plan tf_apply terraform tf_destroy

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -7,7 +7,7 @@ __check_defined = \
         $(error Environment variable $1$(if $2, ($2)) is not set))
 
 # GitHub Actions local testing with act
-.PHONY: act-bootstrap act-terraform
+.PHONY: act-bootstrap act-terraform act-mock
 
 act-bootstrap:
 	@if [ ! -f "../.env.local-test" ]; then \
@@ -26,6 +26,14 @@ act-terraform:
 	@echo "Testing terraform job locally with act..."
 	@cd .. && act -j terraform -W .github/workflows/terraform-bootstrap.yml \
 		--secret-file .env.local-test
+
+act-mock:
+	@if [ ! -f "../.env.local-test" ]; then \
+		echo "Error: .env.local-test file not found in root directory"; \
+		exit 1; \
+	fi
+	@echo "Testing workflow with mock AWS operations..."
+	@cd .. && ./act-mock.sh
 
 # Load environment variables from .env files
 load-env:
@@ -129,6 +137,7 @@ help:
 	@echo "GitHub Actions Testing:"
 	@echo "  act-bootstrap    - Test bootstrap job locally with act"
 	@echo "  act-terraform    - Test terraform job locally with act"
+	@echo "  act-mock        - Test workflow with mock AWS operations (recommended)"
 	@echo ""
 	@echo "Setup:"
 	@echo "  aws-prepare     - Package Lambda function for AWS deployment"


### PR DESCRIPTION
This PR adds a new target to the Makefiles to make it easier to run Act with mock AWS operations. This is the recommended way to test the GitHub Actions workflow locally.